### PR TITLE
Of 3257 scram sha1 constant time

### DIFF
--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
@@ -555,7 +555,7 @@ public class ScramSha1SaslServer implements SaslServer {
     {
         try {
             return ScramUtils.computeHmac(
-                SERVER_SECRET_NONEXISTENT_USERS.getValue().getBytes(StandardCharsets.UTF_8),
+                getServerSecretForNonExistentUsers().getBytes(StandardCharsets.UTF_8),
                 input
             );
         } catch (SaslException e) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
@@ -223,8 +223,8 @@ public class ScramSha1SaslServer implements SaslServer {
 //        String channelBinding = m.group(2);
         String clientNonce = m.group(3);
         String proof = m.group(4);
-        
-        if (!nonce.equals(clientNonce)) {
+
+        if (!nonce.equals(clientNonce)) { // Constant-time operation is important for keys, not for public protocol values like nonces.
             throw new SaslException("Client final message has incorrect nonce value");
         }
 
@@ -242,7 +242,7 @@ public class ScramSha1SaslServer implements SaslServer {
                 clientKey[i] ^= decodedProof[i];
             }
 
-            if (!Arrays.equals(storedKey, MessageDigest.getInstance("SHA-1").digest(clientKey))) {
+            if (!MessageDigest.isEqual(storedKey, MessageDigest.getInstance("SHA-1").digest(clientKey))) {
                 throw new SaslException("Authentication failed for: '"+username+"'");
             }
             return ("v=" + DatatypeConverter.printBase64Binary(serverSignature))

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
@@ -230,14 +230,8 @@ public class ScramSha1SaslServer implements SaslServer {
 
         try {
             String authMessage = clientFirstMessageBare + "," + serverFirstMessage + "," + clientFinalMessageWithoutProof;
-            byte[] storedKey = getStoredKey( username );
-            if (storedKey == null) {
-                throw new SaslException("No stored key for user '"+username+"'");
-            }
-            byte[] serverKey = getServerKey(username);
-            if (serverKey == null) {
-                throw new SaslException("No server key for user '"+username+"'");
-            }
+            byte[] storedKey = getOrFakeStoredKey(username);
+            byte[] serverKey = getOrFakeServerKey(username);
 
             byte[] clientSignature = ScramUtils.computeHmac(storedKey, authMessage);
             byte[] serverSignature = ScramUtils.computeHmac(serverKey, authMessage);
@@ -253,18 +247,18 @@ public class ScramSha1SaslServer implements SaslServer {
             }
             return ("v=" + DatatypeConverter.printBase64Binary(serverSignature))
                     .getBytes(StandardCharsets.UTF_8);
-        } catch (UserNotFoundException | NoSuchAlgorithmException e) {
+        } catch (NoSuchAlgorithmException e) {
             throw new SaslException(e.getMessage(), e);
         }
     }
 
     /**
-      * Determines whether the authentication exchange has completed.
-      * This method is typically called after each invocation of
-      * {@code evaluateResponse()} to determine whether the
-      * authentication has completed successfully or should be continued.
-      * @return true if the authentication exchange has completed; false otherwise.
-      */
+     * Determines whether the authentication exchange has completed.
+     * This method is typically called after each invocation of
+     * {@code evaluateResponse()} to determine whether the
+     * authentication has completed successfully or should be continued.
+     * @return true if the authentication exchange has completed; false otherwise.
+     */
     @Override
     public boolean isComplete() {
         return state == State.COMPLETE;
@@ -352,7 +346,7 @@ public class ScramSha1SaslServer implements SaslServer {
         username = null;
         state = State.INITIAL;
     }
-    
+
     /**
      * Retrieve the salt for a given username.
      *
@@ -484,7 +478,28 @@ public class ScramSha1SaslServer implements SaslServer {
             return ITERATION_COUNT.getValue();
         }
     }
-    
+
+    /**
+     * Retrieve the server key from the database for a given username, but returns a fake key if none is found.
+     *
+     * Returning a fake key helps guard against timing attacks: instead of short-circuiting the operation,
+     * a fake key is generated to ensure consistent response times and prevent potential timing attacks.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3257">OF-3257: Guard against timing attacks in ScramSha1SaslServer</a>
+     */
+    @VisibleForTesting
+    byte[] getOrFakeServerKey(String username) {
+        try {
+            byte[] key = getServerKey(username);
+            if (key != null) {
+                return key;
+            }
+        } catch (UserNotFoundException ignored) {
+            // fall through
+        }
+        return generateFakeKey("server-key-" + username);
+    }
+
     /**
      * Retrieve the server key from the database for a given username.
      */
@@ -496,7 +511,28 @@ public class ScramSha1SaslServer implements SaslServer {
             return DatatypeConverter.parseBase64Binary( serverKey );
         }
     }
-    
+
+    /**
+     * Retrieve the stored key from the database for a given username, but returns a fake key if none is found.
+     *
+     * Returning a fake key helps guard against timing attacks: instead of short-circuiting the operation,
+     * a fake key is generated to ensure consistent response times and prevent potential timing attacks.
+     *
+     * @see <a href="https://igniterealtime.atlassian.net/browse/OF-3257">OF-3257: Guard against timing attacks in ScramSha1SaslServer</a>
+     */
+    @VisibleForTesting
+    byte[] getOrFakeStoredKey(final String username) {
+        try {
+            byte[] key = getStoredKey(username);
+            if (key != null) {
+                return key;
+            }
+        } catch (UserNotFoundException ignored) {
+            // fall through
+        }
+        return generateFakeKey("stored-key-" + username);
+    }
+
     /**
      * Retrieve the stored key from the database for a given username.
      */
@@ -506,6 +542,26 @@ public class ScramSha1SaslServer implements SaslServer {
             return null;
         } else {
             return DatatypeConverter.parseBase64Binary( storedKey );
+        }
+    }
+
+    /**
+     * Generate a fake key to guard against timing attacks (see OF-3258).
+     *
+     * @param input a string input for which to generate a fake key
+     * @return a fake key
+     */
+    private byte[] generateFakeKey(String input)
+    {
+        try {
+            return ScramUtils.computeHmac(
+                SERVER_SECRET_NONEXISTING_USERS.getValue().getBytes(StandardCharsets.UTF_8),
+                input
+            );
+        } catch (SaslException e) {
+            byte[] fallback = new byte[24];
+            random.nextBytes(fallback);
+            return fallback;
         }
     }
 }

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
@@ -545,7 +545,7 @@ public class ScramSha1SaslServer implements SaslServer {
     }
 
     /**
-     * Generate a fake key to guard against timing attacks (see OF-3258).
+     * Generate a fake key to guard against timing attacks (see OF-3257).
      *
      * @param input a string input for which to generate a fake key
      * @return a fake key

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
@@ -555,7 +555,7 @@ public class ScramSha1SaslServer implements SaslServer {
     {
         try {
             return ScramUtils.computeHmac(
-                SERVER_SECRET_NONEXISTING_USERS.getValue().getBytes(StandardCharsets.UTF_8),
+                SERVER_SECRET_NONEXISTENT_USERS.getValue().getBytes(StandardCharsets.UTF_8),
                 input
             );
         } catch (SaslException e) {

--- a/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
+++ b/xmppserver/src/main/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServer.java
@@ -20,7 +20,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.util.Arrays;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerFakeKeyTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerFakeKeyTest.java
@@ -41,6 +41,13 @@ public class ScramSha1SaslServerFakeKeyTest
         Fixtures.disableDatabasePersistence();
     }
 
+    @AfterEach
+    public void resetProperty() throws Exception
+    {
+        // Prevent order-dependent failures by resetting the property after each test.
+        ScramSha1SaslServer.SERVER_SECRET_NONEXISTENT_USERS.setValue(null);
+    }
+
     /**
      * The fake key for a given username and secret should be deterministic.
      */

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerFakeKeyTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerFakeKeyTest.java
@@ -48,7 +48,7 @@ public class ScramSha1SaslServerFakeKeyTest
     void fakeKeyIsDeterministicForSameInput()
     {
         // Setup test fixture
-        ScramSha1SaslServer.SERVER_SECRET_NONEXISTING_USERS.setValue(SERVER_SECRET_1);
+        ScramSha1SaslServer.SERVER_SECRET_NONEXISTENT_USERS.setValue(SERVER_SECRET_1);
         final ScramSha1SaslServer server = new ScramSha1SaslServer();
 
         // Execute system under test
@@ -66,7 +66,7 @@ public class ScramSha1SaslServerFakeKeyTest
     void fakeKeysDifferForDifferentUsernames()
     {
         // Setup test fixture
-        ScramSha1SaslServer.SERVER_SECRET_NONEXISTING_USERS.setValue(SERVER_SECRET_1);
+        ScramSha1SaslServer.SERVER_SECRET_NONEXISTENT_USERS.setValue(SERVER_SECRET_1);
         final ScramSha1SaslServer server = new ScramSha1SaslServer();
 
         // Execute system under test
@@ -84,12 +84,12 @@ public class ScramSha1SaslServerFakeKeyTest
     void fakeKeyChangesWhenServerSecretChanges()
     {
         // Setup test fixture
-        ScramSha1SaslServer.SERVER_SECRET_NONEXISTING_USERS.setValue(SERVER_SECRET_1);
+        ScramSha1SaslServer.SERVER_SECRET_NONEXISTENT_USERS.setValue(SERVER_SECRET_1);
         final ScramSha1SaslServer server = new ScramSha1SaslServer();
 
         // Execute system under test
         final byte[] key1 = server.getOrFakeStoredKey(USERNAME1);
-        ScramSha1SaslServer.SERVER_SECRET_NONEXISTING_USERS.setValue(SERVER_SECRET_2);
+        ScramSha1SaslServer.SERVER_SECRET_NONEXISTENT_USERS.setValue(SERVER_SECRET_2);
         final byte[] key2 = server.getOrFakeStoredKey(USERNAME1);
 
         // Verify result
@@ -103,7 +103,7 @@ public class ScramSha1SaslServerFakeKeyTest
     void fakeKeyHasExpectedLength()
     {
         // Setup test fixture
-        ScramSha1SaslServer.SERVER_SECRET_NONEXISTING_USERS.setValue(SERVER_SECRET_1);
+        ScramSha1SaslServer.SERVER_SECRET_NONEXISTENT_USERS.setValue(SERVER_SECRET_1);
         final ScramSha1SaslServer server = new ScramSha1SaslServer();
 
         // Execute system under test
@@ -120,7 +120,7 @@ public class ScramSha1SaslServerFakeKeyTest
     void storedAndServerKeysDifferForSameUsername()
     {
         // Setup test fixture
-        ScramSha1SaslServer.SERVER_SECRET_NONEXISTING_USERS.setValue(SERVER_SECRET_1);
+        ScramSha1SaslServer.SERVER_SECRET_NONEXISTENT_USERS.setValue(SERVER_SECRET_1);
         final ScramSha1SaslServer server = new ScramSha1SaslServer();
 
         // Execute system under test

--- a/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerFakeKeyTest.java
+++ b/xmppserver/src/test/java/org/jivesoftware/openfire/sasl/ScramSha1SaslServerFakeKeyTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2026 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.sasl;
+
+import org.jivesoftware.Fixtures;
+import org.junit.jupiter.api.*;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for fake key generation in {@link ScramSha1SaslServer}.
+ */
+public class ScramSha1SaslServerFakeKeyTest
+{
+    private static final String USERNAME1 = "fakeuser1";
+    private static final String USERNAME2 = "fakeuser2";
+    private static final String SERVER_SECRET_1 = "test-secret-1234567890";
+    private static final String SERVER_SECRET_2 = "another-secret-0987654321";
+
+    /**
+     * Prepare the Openfire environment for unit tests.
+     */
+    @BeforeAll
+    public static void setUpClass() throws Exception
+    {
+        Fixtures.reconfigureOpenfireHome();
+        Fixtures.disableDatabasePersistence();
+    }
+
+    /**
+     * The fake key for a given username and secret should be deterministic.
+     */
+    @Test
+    void fakeKeyIsDeterministicForSameInput()
+    {
+        // Setup test fixture
+        ScramSha1SaslServer.SERVER_SECRET_NONEXISTING_USERS.setValue(SERVER_SECRET_1);
+        final ScramSha1SaslServer server = new ScramSha1SaslServer();
+
+        // Execute system under test
+        final byte[] key1 = server.getOrFakeStoredKey(USERNAME1);
+        final byte[] key2 = server.getOrFakeStoredKey(USERNAME1);
+
+        // Verify result
+        assertArrayEquals(key1, key2, "Fake key should be deterministic for same input and secret");
+    }
+
+    /**
+     * Fake keys for different usernames should differ.
+     */
+    @Test
+    void fakeKeysDifferForDifferentUsernames()
+    {
+        // Setup test fixture
+        ScramSha1SaslServer.SERVER_SECRET_NONEXISTING_USERS.setValue(SERVER_SECRET_1);
+        final ScramSha1SaslServer server = new ScramSha1SaslServer();
+
+        // Execute system under test
+        final byte[] key1 = server.getOrFakeStoredKey(USERNAME1);
+        final byte[] key2 = server.getOrFakeStoredKey(USERNAME2);
+
+        // Verify result
+        assertFalse(Arrays.equals(key1, key2), "Fake keys should differ for different usernames");
+    }
+
+    /**
+     * Fake key should change if the server secret changes.
+     */
+    @Test
+    void fakeKeyChangesWhenServerSecretChanges()
+    {
+        // Setup test fixture
+        ScramSha1SaslServer.SERVER_SECRET_NONEXISTING_USERS.setValue(SERVER_SECRET_1);
+        final ScramSha1SaslServer server = new ScramSha1SaslServer();
+
+        // Execute system under test
+        final byte[] key1 = server.getOrFakeStoredKey(USERNAME1);
+        ScramSha1SaslServer.SERVER_SECRET_NONEXISTING_USERS.setValue(SERVER_SECRET_2);
+        final byte[] key2 = server.getOrFakeStoredKey(USERNAME1);
+
+        // Verify result
+        assertFalse(Arrays.equals(key1, key2), "Fake key should change when server secret changes");
+    }
+
+    /**
+     * Fake key should have a reasonable length (e.g., 20 bytes for HMAC-SHA1 output).
+     */
+    @Test
+    void fakeKeyHasExpectedLength()
+    {
+        // Setup test fixture
+        ScramSha1SaslServer.SERVER_SECRET_NONEXISTING_USERS.setValue(SERVER_SECRET_1);
+        final ScramSha1SaslServer server = new ScramSha1SaslServer();
+
+        // Execute system under test
+        final byte[] key = server.getOrFakeStoredKey(USERNAME1);
+
+        // Verify result (HMAC-SHA1 output is 20 bytes)
+        assertEquals(20, key.length, "Fake key should be 20 bytes (SHA-1 hash length)");
+    }
+
+    /**
+     * Stored and server keys should differ for the same username.
+     */
+    @Test
+    void storedAndServerKeysDifferForSameUsername()
+    {
+        // Setup test fixture
+        ScramSha1SaslServer.SERVER_SECRET_NONEXISTING_USERS.setValue(SERVER_SECRET_1);
+        final ScramSha1SaslServer server = new ScramSha1SaslServer();
+
+        // Execute system under test
+        final byte[] stored = server.getOrFakeStoredKey(USERNAME1);
+        final byte[] serverKey = server.getOrFakeServerKey(USERNAME1);
+
+        assertFalse(Arrays.equals(stored, serverKey), "Stored key and server key should differ for same username");
+    }
+}
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SCRAM authentication now gracefully handles missing user credentials without throwing exceptions.

* **Security**
  * Authentication verification now uses constant-time comparison to prevent timing attacks.

* **Tests**
  * Added comprehensive test coverage for SCRAM authentication credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->